### PR TITLE
Fix mint csv import

### DIFF
--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,3 @@
+class Label < ActiveRecord::Base
+  has_and_belongs_to_many :user_transactions, class_name: 'Transaction', foreign_key: :label_id
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -5,17 +5,9 @@ class Transaction < ApplicationRecord
   belongs_to :user
   belongs_to :transaction_group, primary_key: :uuid, foreign_key: :transaction_group_uuid, optional: true
 
-  before_update :normalize_category
-
   scope :by_date, -> { order('date DESC') }
 
   def grouped_transactions
     transaction_group&.transactions&.where&.not(id: self.id) || []
-  end
-
-  private
-
-  def normalize_category
-    self.category = PlaidCategory.find_by(category_id: category_id).hierarchy
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -5,6 +5,7 @@ class Transaction < ApplicationRecord
   belongs_to :user
   belongs_to :transaction_group, primary_key: :uuid, foreign_key: :transaction_group_uuid, optional: true
   belongs_to :plaid_category
+  has_and_belongs_to_many :labels
 
   scope :by_date, -> { order('date DESC') }
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -4,6 +4,7 @@ class Transaction < ApplicationRecord
   belongs_to :account
   belongs_to :user
   belongs_to :transaction_group, primary_key: :uuid, foreign_key: :transaction_group_uuid, optional: true
+  belongs_to :plaid_category
 
   scope :by_date, -> { order('date DESC') }
 

--- a/db/migrate/20231112194101_update_plaid_category_columns.rb
+++ b/db/migrate/20231112194101_update_plaid_category_columns.rb
@@ -1,0 +1,12 @@
+class UpdatePlaidCategoryColumns < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :plaid_categories, :category_id
+
+    remove_column :plaid_categories, :hierarchy
+    remove_column :plaid_categories, :category_id
+
+    add_column :plaid_categories, :primary_category, :string
+    add_column :plaid_categories, :detailed_category, :string
+    add_column :plaid_categories, :description, :string
+  end
+end

--- a/db/migrate/20231112201809_add_foreign_key_to_transactions_plaid_category.rb
+++ b/db/migrate/20231112201809_add_foreign_key_to_transactions_plaid_category.rb
@@ -1,0 +1,10 @@
+class AddForeignKeyToTransactionsPlaidCategory < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :transactions, :plaid_category
+
+    add_index :transactions, :id
+
+    remove_column :transactions, :primary_category
+    remove_column :transactions, :detailed_category
+  end
+end

--- a/db/migrate/20231115000550_create_transactions_labels_join_table.rb
+++ b/db/migrate/20231115000550_create_transactions_labels_join_table.rb
@@ -1,0 +1,16 @@
+class CreateTransactionsLabelsJoinTable < ActiveRecord::Migration[7.1]
+  def change
+    create_table :labels do |t|
+      t.string :name
+    end
+
+    create_table :labels_transactions, id: false do |t|
+      t.string :transaction_id, null: false
+      t.bigint :label_id, null: false
+
+      t.index [:label_id, :transaction_id], unique: true
+      t.index :label_id
+      t.index :transaction_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_10_163511) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_12_194101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -61,11 +61,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_10_163511) do
   end
 
   create_table "plaid_categories", force: :cascade do |t|
-    t.jsonb "hierarchy"
-    t.string "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["category_id"], name: "index_plaid_categories_on_category_id"
+    t.string "primary_category"
+    t.string "detailed_category"
+    t.string "description"
   end
 
   create_table "plaid_credentials", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_12_194101) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_12_201809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -114,13 +114,14 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_12_194101) do
     t.datetime "updated_at", null: false
     t.boolean "split", default: false
     t.uuid "transaction_group_uuid"
-    t.string "primary_category"
-    t.string "detailed_category"
     t.string "category_confidence"
     t.string "merchant_name"
     t.datetime "deleted_at"
+    t.bigint "plaid_category_id"
     t.index ["account_id"], name: "index_transactions_on_account_id"
     t.index ["deleted_at"], name: "index_transactions_on_deleted_at"
+    t.index ["id"], name: "index_transactions_on_id"
+    t.index ["plaid_category_id"], name: "index_transactions_on_plaid_category_id"
     t.index ["transaction_group_uuid"], name: "index_transactions_on_transaction_group_uuid"
     t.index ["user_id"], name: "index_transactions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_12_201809) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_15_000550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -58,6 +58,18 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_12_201809) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_balances_on_account_id"
+  end
+
+  create_table "labels", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "labels_transactions", id: false, force: :cascade do |t|
+    t.string "transaction_id", null: false
+    t.bigint "label_id", null: false
+    t.index ["label_id", "transaction_id"], name: "index_labels_transactions_on_label_id_and_transaction_id", unique: true
+    t.index ["label_id"], name: "index_labels_transactions_on_label_id"
+    t.index ["transaction_id"], name: "index_labels_transactions_on_transaction_id"
   end
 
   create_table "plaid_categories", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,5 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# Put any seed scripts that need to be run into db/seeds to automatically
+# run the script when bundle exec rake db:seed is called
+Dir.glob(Rails.root.join('db', 'seeds', '*.rb')).each do |seed_file|
+  load seed_file
+end

--- a/db/seeds/categories.rb
+++ b/db/seeds/categories.rb
@@ -5,7 +5,7 @@ response = Faraday.new(url: 'https://plaid.com/documents/transactions-personal-f
 puts "Failure response retrieving plaid transaction categories - status: #{response.status}" unless response.success?
 
 records_inserted = 0
-p "Seeding categories from plaid"
+puts "Seeding categories from plaid"
 CSV.parse(response.body, headers: true).each do |row|
   PlaidCategory.find_or_create_by(primary_category: row['PRIMARY'], detailed_category: row['DETAILED']) do |record|
     record.description = row['DESCRIPTION']
@@ -13,7 +13,7 @@ CSV.parse(response.body, headers: true).each do |row|
   end
 end
 
-p "Seeding custom categories from custom_categories.csv"
+puts "Seeding custom categories from custom_categories.csv"
 CSV.open(Rails.root.join('db', 'seeds', 'custom_categories.csv'), headers: true).each do |row|
   PlaidCategory.find_or_create_by(primary_category: row['PRIMARY'], detailed_category: row['DETAILED']) do |record|
     record.description = row['DESCRIPTION']
@@ -21,4 +21,4 @@ CSV.open(Rails.root.join('db', 'seeds', 'custom_categories.csv'), headers: true)
   end
 end
 
-p "Successfully seeded #{records_inserted} categories"
+puts "Successfully seeded #{records_inserted} categories"

--- a/db/seeds/categories.rb
+++ b/db/seeds/categories.rb
@@ -1,0 +1,24 @@
+require 'faraday'
+require 'csv'
+
+response = Faraday.new(url: 'https://plaid.com/documents/transactions-personal-finance-category-taxonomy.csv').get
+puts "Failure response retrieving plaid transaction categories - status: #{response.status}" unless response.success?
+
+records_inserted = 0
+p "Seeding categories from plaid"
+CSV.parse(response.body, headers: true).each do |row|
+  PlaidCategory.find_or_create_by(primary_category: row['PRIMARY'], detailed_category: row['DETAILED']) do |record|
+    record.description = row['DESCRIPTION']
+    records_inserted += 1
+  end
+end
+
+p "Seeding custom categories from custom_categories.csv"
+CSV.open(Rails.root.join('db', 'seeds', 'custom_categories.csv'), headers: true).each do |row|
+  PlaidCategory.find_or_create_by(primary_category: row['PRIMARY'], detailed_category: row['DETAILED']) do |record|
+    record.description = row['DESCRIPTION']
+    records_inserted += 1
+  end
+end
+
+p "Successfully seeded #{records_inserted} categories"

--- a/db/seeds/custom_categories.csv
+++ b/db/seeds/custom_categories.csv
@@ -1,0 +1,11 @@
+PRIMARY,DETAILED,DESCRIPTION
+FOOD_AND_DRINK,FOOD_AND_DRINK_LUNCH,Money spent on lunch while working
+FOOD_AND_DRINK,FOOD_AND_DRINK_FOOD_DELIVERY,Purchases made for food delivery
+GENERAL_MERCHANDISE,GENERAL_MERCHANDISE_ENGAGEMENT_RING,Engagement ring
+PERSONAL_CARE,PERSONAL_CARE_SPORTS,"Sports leagues,and recreational sports"
+LOAN_PAYMENTS,LOAN_PAYMENTS_DOWN_PAYMENT,Down payment for a mortgage
+GENERAL_SERVICES,GENERAL_SERVICES_MOVING,"Move in fees, movers, and other miscellaneous moving expenses"
+INCOME,INCOME_BONUS,Income earned as a bonus
+GENERAL_SERVICES,GENERAL_SERVICES_WEDDING,"Wedding venue, vendors, and associated expenses"
+TRAVEL,TRAVEL_VACATION,General expenses incurred while on vacation
+EXCLUDED,EXCLUDED_EXCLUDED,Transactions excluded or otherwise ignored for personal finance purposes

--- a/lib/csv_import/constants/mint.rb
+++ b/lib/csv_import/constants/mint.rb
@@ -1,6 +1,10 @@
 module CsvImport
   module Constants
     class Mint
+      class TransactionType
+        CREDIT = 'credit'.freeze
+        DEBIT = 'debit'.freeze
+      end
 
       def map_category(category, description)
         self.class.mappings.dig(category).call(description)
@@ -28,7 +32,7 @@ module CsvImport
             'Books & Supplies' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_BOOKSTORES_AND_NEWSSTANDS'],
             'Student Loan' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_STUDENT_LOAN_PAYMENT'],
             'Tuition' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_EDUCATION'],
-            'Amusement' => 'Entertainment',
+            'Amusement' => ['ENTERTAINMENT', 'ENTERTAINMENT_OTHER_ENTERTAINMENT'],
             'Arts' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_OTHER_GENERAL_MERCHANDISE'],
             'Movies & DVDs' => ['ENTERTAINMENT', 'ENTERTAINMENT_TV_AND_MOVIES'],
             'Music' => ['ENTERTAINMENT', 'ENTERTAINMENT_MUSIC_AND_AUDIO'],
@@ -85,7 +89,7 @@ module CsvImport
             'Loan Payment' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_MORTGAGE_PAYMENT'],
             'Loan Principal' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_MORTGAGE_PAYMENT'],
             'Loans' => ['EXCLUDED', 'EXCLUDED_EXCLUDED'],
-            'Wedding' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_WEDDING'],
+            'Wedding' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_WEDDING'],
             'Hair' => ['PERSONAL_CARE', 'PERSONAL_CARE_HAIR_AND_BEAUTY'],
             'Laundry' => ['PERSONAL_CARE', 'PERSONAL_CARE_LAUNDRY_AND_DRY_CLEANING'],
             'Spa & Massage' => ['PERSONAL_CARE', 'PERSONAL_CARE_HAIR_AND_BEAUTY'],

--- a/lib/csv_import/constants/mint.rb
+++ b/lib/csv_import/constants/mint.rb
@@ -9,133 +9,129 @@ module CsvImport
       def self.mappings
         @mappings ||= begin
           conversions = {
-            'Auto Insurance' => 'Insurance',
-            'Auto Payment' => 'Payment',
-            'Gas & Fuel' => 'Gas Stations',
-            'Parking' => 'Parking',
-            'Public Transportation' => 'Public Transportation Services',
-            'Service & Parts' => 'Car Service',
-            'Home Phone' => 'Mobile Phone',
-            'Internet' => 'Internet Services',
-            'Mobile Phone' => 'Mobile Phone',
-            'Television' => 'Utilities',
-            'Utilities' => 'Utilities',
-            'Advertising' => 'Advertising and Marketing',
-            'Legal' => 'Legal',
-            'Office Supplies' => 'Office Supplies',
-            'Printing' => 'Printing and Publishing',
-            'Shipping' => 'Shipping and Freight',
-            'Books & Supplies' => 'Bookstores',
-            'Student Loan' => 'Loan',
-            'Tuition' => 'Colleges and Universities',
+            'Auto Insurance' => ['GENERAL_SERVICES', 'LOAN_PAYMENTS_CAR_PAYMENT'],
+            'Auto Payment' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_CAR_PAYMENT'],
+            'Gas & Fuel' => ['TRANSPORTATION', 'TRANSPORTATION_GAS'],
+            'Parking' => ['TRANSPORTATION', 'TRANSPORTATION_PARKING'],
+            'Public Transportation' => ['TRANSPORTATION', 'TRANSPORTATION_PUBLIC_TRANSIT'],
+            'Service & Parts' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_AUTOMOTIVE'],
+            'Home Phone' => ['RENT_AND_UTILITIES', 'RENT_AND_UTILITIES_TELEPHONE'],
+            'Internet' => ['RENT_AND_UTILITIES', 'RENT_AND_UTILITIES_INTERNET_AND_CABLE'],
+            'Mobile Phone' => ['RENT_AND_UTILITIES', 'RENT_AND_UTILITIES_TELEPHONE'],
+            'Television' => ['RENT_AND_UTILITIES', 'RENT_AND_UTILITIES_INTERNET_AND_CABLE'],
+            'Utilities' => ['RENT_AND_UTILITIES', 'RENT_AND_UTILITIES_GAS_AND_ELECTRICITY'],
+            'Advertising' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_OTHER_GENERAL_SERVICES'],
+            'Legal' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_CONSULTING_AND_LEGAL'],
+            'Office Supplies' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_OFFICE_SUPPLIES'],
+            'Printing' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_POSTAGE_AND_SHIPPING'],
+            'Shipping' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_POSTAGE_AND_SHIPPING'],
+            'Books & Supplies' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_BOOKSTORES_AND_NEWSSTANDS'],
+            'Student Loan' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_STUDENT_LOAN_PAYMENT'],
+            'Tuition' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_EDUCATION'],
             'Amusement' => 'Entertainment',
-            'Arts' => 'Arts and Entertainment',
-            'Movies & DVDs' => 'Movie Theatres',
-            'Music' => 'Music, Video and DVD',
-            'Newspapers & Magazines' => 'Newsstands',
-            'Relaxation' => 'Entertainment',
-            'Sports Tickets' => 'Sports Venues',
-            'ATM Fee' => 'Bank Fee',
-            'Bank Fee' => 'Bank Fee',
-            'Finance Charge' => 'Bank Fee',
-            'Late Fee' => 'Bank Fee',
-            'Service Fee' => 'Bank Fee',
-            'Trade Commissions' => 'Bank Fee',
-            'Financial Advisor' => 'Financial Planning and Investments',
-            'Life Insurance    ' => 'Insurance',
-            'Alcohol & Bars' => 'Bar',
-            'Coffee Shops' => 'Coffee Shop',
-            'Fast Food' => 'Fast Food',
-            'Groceries' => 'Supermarkets and Groceries',
-            'Restaurants' => 'Restaurants',
-            'Lunch' => 'Lunch',
-            'Charity' => 'Charities and Non-Profits',
-            'Gift' => 'Gift and Novelty',
-            'Engagement Ring' => 'Engagement Ring',
-            'Dentist' => 'Dentists',
-            'Doctor' => 'Healthcare',
-            'Eyecare' => 'Glasses and Optometrist',
-            'Gym' => 'Gyms and Fitness Centers',
-            'Health Insurance' => 'Insurance',
-            'Pharmacy' => 'Pharmacies',
-            'Sports' => ->(description) { classify_sports_category(description) },
-            'Furnishings' => 'Furniture and Home Decor',
-            'Home Improvement' => 'Home Improvement',
-            'Home Insurance' => 'Insurance',
-            'Home Services' => 'Home Improvement',
-            'Home Supplies' => 'Home Improvement',
-            'Lawn & Garden' => 'Lawn & Garden',
+            'Arts' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_OTHER_GENERAL_MERCHANDISE'],
+            'Movies & DVDs' => ['ENTERTAINMENT', 'ENTERTAINMENT_TV_AND_MOVIES'],
+            'Music' => ['ENTERTAINMENT', 'ENTERTAINMENT_MUSIC_AND_AUDIO'],
+            'Newspapers & Magazines' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_BOOKSTORES_AND_NEWSSTANDS'],
+            'Relaxation' => ['ENTERTAINMENT', 'ENTERTAINMENT_OTHER_ENTERTAINMENT'],
+            'Sports Tickets' => ['ENTERTAINMENT', 'ENTERTAINMENT_SPORTING_EVENTS_AMUSEMENT_PARKS_AND_MUSEUMS'],
+            'ATM Fee' => ['BANK_FEES', 'BANK_FEES_ATM_FEES'],
+            'Bank Fee' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Finance Charge' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Late Fee' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Service Fee' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Trade Commissions' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Financial Advisor' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_ACCOUNTING_AND_FINANCIAL_PLANNING'],
+            'Life Insurance    ' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_INSURANCE'],
+            'Alcohol & Bars' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_RESTAURANT'],
+            'Coffee Shops' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_COFFEE'],
+            'Fast Food' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_FAST_FOOD'],
+            'Groceries' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_GROCERIES'],
+            'Restaurants' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_RESTAURANT'],
+            'Lunch' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_LUNCH'],
+            'Charity' => ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_DONATIONS'],
+            'Gift' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_GIFTS_AND_NOVELTIES'],
+            'Gifts & Donations' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_GIFTS_AND_NOVELTIES'],
+            'Engagement Ring' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_ENGAGEMENT_RING'],
+            'Dentist' => ['MEDICAL', 'MEDICAL_DENTAL_CARE'],
+            'Doctor' => ['MEDICAL', 'MEDICAL_PRIMARY_CARE'],
+            'Eyecare' => ['MEDICAL', 'MEDICAL_EYE_CARE'],
+            'Gym' => ['PERSONAL_CARE', 'PERSONAL_CARE_GYMS_AND_FITNESS_CENTERS'],
+            'Health Insurance' => ['GENERAL_SERVICES', 'PERSONAL_CARE_GYMS_AND_FITNESS_CENTERS'],
+            'Pharmacy' => ['MEDICAL', 'MEDICAL_PHARMACIES_AND_SUPPLEMENTS'],
+            'Sports' => ['PERSONAL_CARE', 'PERSONAL_CARE_SPORTS'],
+            'Furnishings' => ['HOME_IMPROVEMENT', 'HOME_IMPROVEMENT_FURNITURE'],
+            'Home Improvement' => ['HOME_IMPROVEMENT', 'HOME_IMPROVEMENT_REPAIR_AND_MAINTENANCE'],
+            'Home Insurance' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_INSURANCE'],
+            'Home Services' => ['HOME_IMPROVEMENT', 'HOME_IMPROVEMENT_REPAIR_AND_MAINTENANCE'],
+            'Home Supplies' => ['HOME_IMPROVEMENT', 'HOME_IMPROVEMENT_HARDWARE'],
+            'Lawn & Garden' => ['HOME_IMPROVEMENT', 'HOME_IMPROVEMENT_HARDWARE'],
             'Mortgage & Rent' => ->(description) { classify_mortgage_and_rent_category(description) },
-            'Down Payment' => 'Down Payment',
-            'Move in fee' => 'Move in Fee',
-            'Moving Expenses' => 'Movers',
-            'Bonus' => 'Bonus',
-            'Interest Income' => 'Interest Earned',
-            'Paycheck' => 'Payroll',
-            'Reimbursement' => 'Payroll',
-            'Rental Income' => 'Rent',
-            'Returned Purchase' => 'Payment',
-            'Buy' => 'Excluded',
-            'Deposit' => 'Deposit',
-            'Dividend & Cap Gains' => 'Financial Planning and Investments',
-            'Sell' => 'Excluded',
-            'Withdrawal' => 'Excluded',
-            'Allowance' => 'Excluded',
-            'Baby Supplies' => 'Children',
-            'Babysitter & Daycare' => 'Children',
-            'Child Support' => 'Children',
-            'Kids Activities' => 'Children',
-            'Toys' => 'Toys',
-            'Loan Fees and Charges' => 'Loan',
-            'Loan Insurance' => 'Loan',
-            'Loan Interest' => 'Loan',
-            'Loan Payment' => 'Payment',
-            'Loan Principal' => 'Payment',
-            'Wedding' => 'Wedding and Bridal',
-            'Hair' => 'Hair Salons and Barbers',
-            'Laundry' => 'Laundry and Garment Services',
-            'Spa & Massage' => 'Spas',
-            'Pet Food & Supplies' => 'Pets',
-            'Pet Grooming' => 'Pets',
-            'Veterinary' => 'Veterinarians',
-            'Books' => 'Bookstores',
-            'Clothing' => 'Clothing and Accessories',
-            'Electronics & Software' => 'Computers and Electronics',
-            'Hobbies' => 'Hobby and Collectibles',
-            'Sporting Goods' => 'Sporting Goods',
-            'Federal Tax' => 'Taxes',
-            'Local Tax' => 'Taxes',
-            'Property Tax' => 'Taxes',
-            'Sales Tax' => 'Taxes',
-            'State Tax' => 'Taxes',
-            'Credit Card Payment' => 'Excluded',
-            'Transfer for Cash Spending' => 'Excluded',
-            'Air Travel' => 'Airlines and Aviation Services',
-            'Hotel' => 'Hotels and Motels',
+            'Down Payment' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_DOWN_PAYMENT'],
+            'Move in fee' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_MOVING'],
+            'Moving Expenses' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_MOVING'],
+            'Bonus' => ['INCOME', 'INCOME_BONUS'],
+            'Interest Income' => ['INCOME', 'INCOME_INTEREST_EARNED'],
+            'Paycheck' => ['INCOME', 'INCOME_WAGES'],
+            'Reimbursement' => ['INCOME', 'INCOME_WAGES'],
+            'Rental Income' => ['INCOME', 'INCOME_OTHER_INCOME'],
+            'Returned Purchase' => ['INCOME', 'INCOME_OTHER_INCOME'],
+            'Buy' => ['TRANSFER_OUT', 'TRANSFER_OUT_INVESTMENT_AND_RETIREMENT_FUNDS'],
+            'Deposit' => ['TRANSFER_IN', 'TRANSFER_IN_DEPOSIT'],
+            'Dividend & Cap Gains' => ['INCOME', 'INCOME_DIVIDENDS'],
+            'Sell' => ['TRANSFER_IN', 'TRANSFER_IN_INVESTMENT_AND_RETIREMENT_FUNDS'],
+            'Withdrawal' => ['TRANSFER_OUT', 'TRANSFER_OUT_INVESTMENT_AND_RETIREMENT_FUNDS'],
+            'Loan Interest' => ['BANK_FEES', 'BANK_FEES_INTEREST_CHARGE'],
+            'Loan Payment' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_MORTGAGE_PAYMENT'],
+            'Loan Principal' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_MORTGAGE_PAYMENT'],
+            'Loans' => ['EXCLUDED', 'EXCLUDED_EXCLUDED'],
+            'Wedding' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_WEDDING'],
+            'Hair' => ['PERSONAL_CARE', 'PERSONAL_CARE_HAIR_AND_BEAUTY'],
+            'Laundry' => ['PERSONAL_CARE', 'PERSONAL_CARE_LAUNDRY_AND_DRY_CLEANING'],
+            'Spa & Massage' => ['PERSONAL_CARE', 'PERSONAL_CARE_HAIR_AND_BEAUTY'],
+            'Pet Food & Supplies' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_PET_SUPPLIES'],
+            'Pet Grooming' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_PET_SUPPLIES'],
+            'Veterinary' => ['MEDICAL', 'MEDICAL_VETERINARY_SERVICES'],
+            'Books' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_BOOKSTORES_AND_NEWSSTANDS'],
+            'Clothing' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_CLOTHING_AND_ACCESSORIES'],
+            'Electronics & Software' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_ELECTRONICS'],
+            'Hobbies' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_OTHER_GENERAL_MERCHANDISE'],
+            'Sporting Goods' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_SPORTING_GOODS'],
+            'Federal Tax' => ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_TAX_PAYMENT'],
+            'Local Tax' => ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_TAX_PAYMENT'],
+            'Property Tax' => ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_TAX_PAYMENT'],
+            'Sales Tax' => ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_TAX_PAYMENT'],
+            'State Tax' => ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_TAX_PAYMENT'],
+            'Credit Card Payment' => ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_CREDIT_CARD_PAYMENT'],
+            'Air Travel' => ['TRAVEL', 'TRAVEL_FLIGHTS'],
+            'Hotel' => ['TRAVEL', 'TRAVEL_LODGING'],
             'Rental Car & Taxi' => ->(description) { classify_rental_car_and_taxi_category(description) },
-            'Vacation' => 'Vacation',
-            'Cash & ATM' => 'ATM',
-            'Check' => 'Check',
-            'Income' => 'Income',
-            'Food & Dining' => 'Food and Drink',
-            'Entertainment' => 'Arts and Entertainment',
-            'Taxes' => 'Taxes',
-            'Shopping' => 'Shops',
-            'Fees & Charges' => 'Bank Fees',
-            'Transfer' => 'Transfer',
-            'Travel' => 'Travel',
-            'Business Services' => 'Business Services',
-            'Health & Fitness' => 'Gyms and Fitness Centers',
-            'Auto & Transport' => 'Tolls and Fees',
-            'Personal Care' => 'Personal Care',
-            'Investments' => 'Excluded',
-            'Financial' => 'Uncategorized',
-            'Education' => 'Education',
-            'Rent application fee' => 'Bank Fee',
-            'Home' => 'Excluded',
-            'Misc Expenses' => 'Excluded',
-            'Hide from Budgets & Trends' => 'Excluded',
-            'Uncategorized' => 'Uncategorized',
+            'Vacation' => ['TRAVEL', 'TRAVEL_VACATION'],
+            'Cash & ATM' => ['TRANSFER_OUT', 'TRANSFER_OUT_WITHDRAWAL'],
+            'Check' => ['TRANSFER_IN', 'TRANSFER_IN_DEPOSIT'],
+            'Income' => ['INCOME', 'INCOME_OTHER_INCOME'],
+            'Food & Dining' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_RESTAURANT'],
+            'Food Delivery' => ['FOOD_AND_DRINK', 'FOOD_AND_DRINK_FOOD_DELIVERY'],
+            'Bills & Utilities' => ['ENTERTAINMENT', 'ENTERTAINMENT_MUSIC_AND_AUDIO'],
+            'Entertainment' => ['ENTERTAINMENT', 'ENTERTAINMENT_OTHER_ENTERTAINMENT'],
+            'Taxes' => ['INCOME', 'INCOME_TAX_REFUND'],
+            'Shopping' => ->(description) { classify_shopping_category(description) },
+            'Fees & Charges' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Transfer' => ->(description) { classify_transfer_category(description) },
+            'Travel' => ->(description) { classify_travel_category(description) },
+            'Business Services' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_OTHER_GENERAL_SERVICES'],
+            'Health & Fitness' => ['PERSONAL_CARE', 'PERSONAL_CARE_GYMS_AND_FITNESS_CENTERS'],
+            'Auto & Transport' => ->(description) { classify_auto_category(description) },
+            'Personal Care' => ['PERSONAL_CARE', 'PERSONAL_CARE_OTHER_PERSONAL_CARE'],
+            'Investments' => ['EXCLUDED', 'EXCLUDED_EXCLUDED'],
+            'Financial' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_ACCOUNTING_AND_FINANCIAL_PLANNING'],
+            'Education' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_OTHER_GENERAL_SERVICES'],
+            'Rent application fee' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
+            'Home' => ['EXCLUDED', 'EXCLUDED_EXCLUDED'],
+            'Ride Share' => ['TRANSPORTATION', 'TRANSPORTATION_TAXIS_AND_RIDE_SHARES'],
+            'Hide from Budgets & Trends' => ['EXCLUDED', 'EXCLUDED_EXCLUDED'],
+            'Uncategorized' => ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_OTHER_GENERAL_MERCHANDISE'],
+            'Honeymoon' => ['TRAVEL', 'TRAVEL_VACATION'],
           }
 
           conversions.each do |_k, value|
@@ -150,32 +146,59 @@ module CsvImport
 
       private
 
-      def self.classify_sports_category(description)
-        if description.match?(/golf/i)
-          'Golf'
-        else
-          'Soccer'
-        end
-      end
-
       def self.classify_mortgage_and_rent_category(description)
         if description.match?(/citizens/i)
-          'Loans and Mortgages'
+          ['LOAN_PAYMENTS', 'LOAN_PAYMENTS_MORTGAGE_PAYMENT']
         else
-          'Rent'
+          ['RENT_AND_UTILITIES', 'RENT_AND_UTILITIES_RENT']
         end
       end
 
       def self.classify_rental_car_and_taxi_category(description)
         if description.match?(/hertz/i) || description.match?(/avis/i) || description.match?(/expedia/i) || description.match?(/alamo/i)
-          'Car and Truck Rentals'
-        elsif description.match?(/uber/i) || description.match?(/lyft/i)
-          'Ride Share'
+          ['TRAVEL', 'TRAVEL_RENTAL_CARS']
         else
-          'Taxi'
+          ['TRANSPORTATION', 'TRANSPORTATION_TAXIS_AND_RIDE_SHARES']
         end
       end
 
+      def self.classify_shopping_category(description)
+        if description.match?(/amazon/i)
+          ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_ONLINE_MARKETPLACES']
+        elsif description.match?(/dollar tree/i) || description.match?(/goodwill/i)
+          ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_DISCOUNT_STORES']
+        else
+          ['GENERAL_MERCHANDISE', 'GENERAL_MERCHANDISE_SUPERSTORES']
+        end
+      end
+
+      def self.classify_transfer_category(description)
+        if description.match?(/venmo.*payment/i)
+          ['TRANSFER_OUT', 'TRANSFER_OUT_ACCOUNT_TRANSFER']
+        else
+          ['TRANSFER_IN', 'TRANSFER_IN_ACCOUNT_TRANSFER']
+        end
+      end
+
+      def self.classify_travel_category(description)
+        if description.match?(/toll/i) || description.match?(/skyway/i) || description.match?(/itr.*concession/i)
+          ['TRANSPORTATION', 'TRANSPORTATION_TOLLS']
+        elsif description.match?(/amtrak/i)
+          ['TRANSPORTATION', 'TRANSPORTATION_PUBLIC_TRANSIT']
+        else
+          ['TRAVEL', 'TRAVEL_OTHER_TRAVEL']
+        end
+      end
+
+      def self.classify_auto_category(description)
+        if description.match?(/toll/i) || description.match?(/bridge/i)
+          ['TRANSPORTATION', 'TRANSPORTATION_TOLLS']
+        elsif description.match?(/sec.*of.*state/i)
+          ['GOVERNMENT_AND_NON_PROFIT', 'GOVERNMENT_AND_NON_PROFIT_GOVERNMENT_DEPARTMENTS_AND_AGENCIES']
+        else
+          ['GENERAL_SERVICES', 'GENERAL_SERVICES_AUTOMOTIVE']
+        end
+      end
     end
   end
 end

--- a/lib/csv_import/importer.rb
+++ b/lib/csv_import/importer.rb
@@ -1,18 +1,56 @@
 require 'csv'
+require 'base64'
+require 'securerandom'
 require_relative 'transaction_category_mapper'
+require_relative 'constants/mint'
 
 module CsvImport
   class Importer
+    class << self
+      def process_csv(filename, user_id)
+        ActiveRecord::Base.transaction do
+          CSV.open(filename, headers: true).each do |row|
+            Transaction.create!(
+              id:                generate_id,
+              user_id:           user_id,
+              description:       row['Description'],
+              amount:            normalize_amount(row),
+              date:              row['Date'],
+              plaid_category_id: map_category(row),
+              labels:            extract_labels(row),
+            )
+          end
+        end
+      end
 
-    def process_csv(csv)
-      csv.blob.open do |raw_file|
-        file = CSV.parse(raw_file, headers: true)
+      def category_mapper
+        @category_mapper ||= TransactionCategoryMapper.new
+      end
+
+      private
+
+      def normalize_amount(row)
+        amount = row['Amount'].to_f
+        if row['Transaction Type'] == CsvImport::Constants::Mint::TransactionType::CREDIT && amount > 0.0 ||
+            row['Transaction Type'] == CsvImport::Constants::Mint::TransactionType::DEBIT && amount < 0.0
+          amount * -1.0 
+        else
+          amount
+        end
+      end
+
+      def extract_labels(row)
+        row['Labels'].split(',').map{ |l| Label.find_or_create_by(name: l) }
+      end
+
+      def map_category(row)
+        category = category_mapper[row]
+        PlaidCategory.find_by(detailed_category: category.last).id
+      end
+
+      def generate_id
+        Base64.encode64(SecureRandom.random_bytes(36))[..-2]
       end
     end
-
-    def category_mapper
-      @category_mapper ||= TransactionCategoryMapper.new(source: :mint)
-    end
-
   end
 end

--- a/lib/csv_import/transaction_category_mapper.rb
+++ b/lib/csv_import/transaction_category_mapper.rb
@@ -11,7 +11,7 @@ module CsvImport
     def [](transaction)
       category = @source_mappings.map_category(transaction.dig('Category'), transaction.dig('Description'))
 
-      raise MappingNotFoundError.new("Could not find mapping for category #{key}") unless category
+      raise MappingNotFoundError.new("Could not find mapping for category #{transaction.dig('Category')} - #{ transaction.dig('Description')}") unless category
 
       category
     end

--- a/lib/csv_import/transaction_category_mapper.rb
+++ b/lib/csv_import/transaction_category_mapper.rb
@@ -1,11 +1,9 @@
 module CsvImport
-  # Utility class for mapping transaction categories
-  # from source (currently only Mint) to plaid 
   class TransactionCategoryMapper
     class MappingNotFoundError < StandardError; end
     
-    def initialize(source:)
-      @source_mappings = load_source_mappings(source.to_s)
+    def initialize
+      @source_mappings = CsvImport::Constants::Mint.new
     end
 
     def [](transaction)
@@ -15,14 +13,5 @@ module CsvImport
 
       category
     end
-
-    private
-
-    def load_source_mappings(source)
-      require 'csv_import/constants/' + source
-      klass = "CsvImport::Constants::#{source.camelize}".constantize
-      klass.new
-    end
-
   end
 end


### PR DESCRIPTION
Update the constants used to map the Mint transaction categories to Plaid transaction categories. Also create a seed script which can be used to re-create that table in an idempotent manner. Use the `db/seeds/custom_categories.csv` file to add new custom categories that are not in the Plaid category taxonomy.