### PR TITLE
Fixes after fully cutting over to using the new Plaid API

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,12 @@
  *= require_tree .
  *= require_self
  */
+
+.green-text {
+  color: #1eae1e;
+}
+
+.pending-transaction-background {
+  background-color: #f4efef;
+}
+

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -46,6 +46,12 @@ class TransactionsController < ApplicationController
     finance_manager.import_transactions_csv(current_user.transaction_csvs.last)
   end
 
+  def hard_delete
+    Transaction.find(params[:transaction_id]).destroy_fully!
+
+    redirect_to action: 'index'
+  end
+
   private
 
   def finance_manager

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
          :trackable
 
   has_many :accounts
-  has_many :transactions, through: :accounts
+  has_many :transactions
   has_many :plaid_credentials
   has_many_attached :transaction_csvs
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,8 @@
 <meta name="description" content="My description">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Personal Finances</title>
+<title>Personal Finance Tracker</title>
+<link rel='icon' type='image/png' href='profits.png'>
 </head>
 
 <%= stylesheet_link_tag "application", media: "all" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= render "shared/header" %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   </head>
-  <%= render "shared/header" %>
 
   <body>
     <%= yield %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -21,7 +21,7 @@
     <div class="ten wide column">
       <h3 class="ui center aligned header">Transactions</h3>
         <div id="recent_transactions">
-          <table class="ui selectable basic table">
+          <table class="ui selectable basic striped table">
             <thead>
               <th>Date</th>
               <th>Description</th>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -21,20 +21,24 @@
     <div class="ten wide column">
       <h3 class="ui center aligned header">Transactions</h3>
         <div id="recent_transactions">
-          <table class="ui selectable basic striped table">
+          <table class="ui selectable basic table">
             <thead>
               <th>Date</th>
               <th>Description</th>
+              <th>Account</th>
               <th>Category</th>
               <th>Amount</th>
             </thead>
             <tbody>
               <% @transactions.each do |transaction| %>
-                <tr data-url="<%= transaction_path(transaction) %>" >
+                <% amount_klass = transaction.amount < 0 ? 'green-text' : 'black-text' %>
+                <% row_klass = transaction.pending ? 'pending-transaction-background': '' %>
+                <tr class="<%= row_klass %>" data-url="<%= transaction_path(transaction) %>" >
                   <td><%= short_format_date(transaction.date) %></td>
-                  <td><%= transaction.description %></td>
+                  <td><%= transaction.description[..40] %></td>
+                  <td><%= transaction.account&.name %></td>
                   <td><%= humanized_category(transaction.plaid_category) %></td>
-                  <td><%= number_to_currency(transaction.amount) %></td>
+                  <td class="<%= amount_klass %>"><%= number_to_currency(transaction.amount * -1.0) %></td>
                 </tr>
               <% end %>
             </tbody>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -86,6 +86,7 @@
       </div>
     </div>
     <div class="one wide column">
+      <%= button_to "Hard Delete", transaction_hard_delete_path(@transaction) %>
     </div>
   </div>
 </body>

--- a/bin/prep_db
+++ b/bin/prep_db
@@ -3,4 +3,5 @@
 bundle exec rake db:drop \
                  db:create \
                  db:schema:load \
-                 db:migrate
+                 db:migrate \
+                 db:seed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
   post '/create_link_token', to: 'plaid#create_link_token'
 
   # Transactions
-  resources :transactions, only: [:index, :show, :update]
+  resources :transactions, only: [:index, :show, :update] do
+    post '/hard_delete', to: 'transactions#hard_delete'
+  end
   resources :split_transactions, only: [:index, :show]
   post '/split_transactions', to: 'transactions#split_transactions'
   post '/upload_csv', to: 'transactions#upload_csv'

--- a/lib/csv_import/constants/mint.rb
+++ b/lib/csv_import/constants/mint.rb
@@ -8,6 +8,8 @@ module CsvImport
 
       def map_category(category, description)
         self.class.mappings.dig(category).call(description)
+      rescue => e
+        puts "Error mapping category: #{category} with description: #{description}"
       end
 
       def self.mappings
@@ -122,6 +124,7 @@ module CsvImport
             'Shopping' => ->(description) { classify_shopping_category(description) },
             'Fees & Charges' => ['BANK_FEES', 'BANK_FEES_OTHER_BANK_FEES'],
             'Transfer' => ->(description) { classify_transfer_category(description) },
+            'Transfer for Cash Spending' => ['TRANSFER_OUT', 'TRANSFER_OUT_WITHDRAWAL'],
             'Travel' => ->(description) { classify_travel_category(description) },
             'Business Services' => ['GENERAL_SERVICES', 'GENERAL_SERVICES_OTHER_GENERAL_SERVICES'],
             'Health & Fitness' => ['PERSONAL_CARE', 'PERSONAL_CARE_GYMS_AND_FITNESS_CENTERS'],

--- a/lib/finance_manager/account.rb
+++ b/lib/finance_manager/account.rb
@@ -12,7 +12,6 @@ module FinanceManager
     end
 
     def self.update(record, account)
-      record.name             = account.name
       record.official_name    = account.official_name
       record.account_type     = account.type
       record.account_sub_type = account.subtype

--- a/lib/finance_manager/account.rb
+++ b/lib/finance_manager/account.rb
@@ -39,6 +39,13 @@ module FinanceManager
     end
 
     def self.create_balance(account, balance)
+      # De-dupe balances so that multiple refreshes per day does not result in duplicate balance records
+      # being created
+      newest_balance = account.balances.order(created_at: :desc).first
+      if  newest_balance.created_at.to_date == Date.today && balance.current == newest_balance.amount
+        return
+      end
+
       Balance.create!(
         account:   account,
         amount:    balance.current,

--- a/lib/finance_manager/interface.rb
+++ b/lib/finance_manager/interface.rb
@@ -125,7 +125,7 @@ module FinanceManager
     private
 
     def transactions_cursor(plaid_cred)
-      plaid_cred.cursor #|| "now"
+      plaid_cred.cursor || "now"
     end
 
   end

--- a/lib/finance_manager/transaction.rb
+++ b/lib/finance_manager/transaction.rb
@@ -40,32 +40,32 @@ module FinanceManager
     end
 
     def self.update(transaction)
-      pending = ::Transaction.find_by(id: transaction.pending_transaction_id)
-      create(transaction) unless pending
+      existing = ::Transaction.find_by(id: transaction.transaction_id)
+      Rails.logger.warn("Could not find transaction to update with id #{transaction.transaction_id}") unless existing
 
       category = ::PlaidCategory.find_by(detailed_category: transaction.personal_finance_category.detailed)
       unknown_category_error(transaction) unless category
 
-      pending.id                     = transaction.id
-      pending.category_confidence    = transaction.category_confidence
-      pending.plaid_category_id      = category.id
-      pending.merchant_name          = transaction.merchant_name
-      pending.payment_channel        = transaction.payment_channel
-      pending.description            = transaction.name
-      pending.amount                 = transaction.amount
-      pending.date                   = transaction.date
-      pending.pending                = transaction.pending
-      pending.payment_metadata       = transaction.payment_meta
-      pending.location_metadata      = transaction.location
-      pending.pending_transaction_id = transaction.pending_transaction_id
-      pending.account_owner          = transaction.account_owner
+      existing.id                     = transaction.transaction_id
+      existing.category_confidence    = transaction.personal_finance_category.confidence_level
+      existing.plaid_category_id      = category.id
+      existing.merchant_name          = transaction.merchant_name
+      existing.payment_channel        = transaction.payment_channel
+      existing.description            = transaction.name
+      existing.amount                 = transaction.amount
+      existing.date                   = transaction.date
+      existing.pending                = transaction.pending
+      existing.payment_metadata       = transaction.payment_meta
+      existing.location_metadata      = transaction.location
+      existing.pending_transaction_id = transaction.pending_transaction_id
+      existing.account_owner          = transaction.account_owner
 
-      pending.save! if pending.changed?
+      existing.save! if existing.changed?
     end
 
     def self.remove(transaction)
-      transaction = ::Transaction.find_by(id: transaction.id)
-      Rails.logger.warn("Could not find transaction to remove with id #{transaction.id}") unless transaction
+      transaction = ::Transaction.find_by(id: transaction.transaction_id)
+      Rails.logger.warn("Could not find transaction to remove with id #{transaction.transaction_id}") unless transaction
 
       transaction.destroy
     end

--- a/lib/finance_manager/transaction.rb
+++ b/lib/finance_manager/transaction.rb
@@ -15,6 +15,11 @@ module FinanceManager
       unknown_account_error(transaction) unless account
       unknown_category_error(transaction) unless category
 
+      if ::Transaction.exists?(transaction.transaction_id)
+        Rails.logger.warn("Duplicate transaction with ID #{transaction.transaction_id} recorded. Ignoring and continuing")
+        return
+      end
+
       ::Transaction.create!(
         account:                account,
         user:                   account.user,

--- a/lib/tasks/match_transactions_to_accounts.rb
+++ b/lib/tasks/match_transactions_to_accounts.rb
@@ -1,0 +1,21 @@
+require 'csv'
+require 'pry'
+
+account_map = Account.all.map{ |a| [a.name, a] }.to_h.merge(Account.all.map{ |a| [a.official_name, a] }.to_h)
+account_map.delete(nil)
+
+count = 0
+ActiveRecord::Base.transaction do
+  CSV.open('transactions.csv', headers: true).each do |row|
+    acct = account_map[row['Account Name']]
+    if acct
+      trans = Transaction.find_by(date: DateTime.strptime(row['Date'], '%m/%d/%Y').in_time_zone,
+                                  description: row['Description'])
+      if trans && trans.account_id.nil?
+        count += 1
+        trans.account_id = acct.id
+        trans.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are various fixes after starting to use the Plaid API for real account and transaction updates. Fixes and improvements include:
* Wrapping all updating of accounts/balances/transactions in a database transaction and rolling back if we encounter an error
* Ensuring we do not create duplicate balance records if accounts are refreshed multiple times per day
* Improving the usability of the transactions page with some small quality of life improvements
* Fixing a few bugs encountered when creating/updating/removing transactions